### PR TITLE
Add make_cache option and make its value equal to enabled

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -31,6 +31,7 @@ yum_repository 'erlang_solutions' do
   include_config node['yum']['erlang_solutions']['include_config']
   includepkgs node['yum']['erlang_solutions']['includepkgs']
   keepalive node['yum']['erlang_solutions']['keepalive']
+  make_cache node['yum']['erlang_solutions']['enabled']
   max_retries node['yum']['erlang_solutions']['max_retries']
   metadata_expire node['yum']['erlang_solutions']['metadata_expire']
   mirror_expire node['yum']['erlang_solutions']['mirror_expire']


### PR DESCRIPTION
If set ['yum']['erlang_solutions']['enabled'] to false,
attribute make_cache is not set, the chef client will run into
error when yum makecache, because the default value of make_cache is true.