### PR TITLE
Removing platform_family check

### DIFF
--- a/attributes/erlang_solutions.rb
+++ b/attributes/erlang_solutions.rb
@@ -1,9 +1,4 @@
-case node['platform_family']
-when 'rhel'
-  default['yum']['erlang_solutions']['baseurl'] = 'http://packages.erlang-solutions.com/rpm/centos/6/$basearch'
-else
-  default['yum']['erlang_solutions']['baseurl'] = 'http://packages.erlang-solutions.com/rpm/centos/$releasever/$basearch'
-end
+default['yum']['erlang_solutions']['baseurl'] = 'http://packages.erlang-solutions.com/rpm/centos/$releasever/$basearch'
 default['yum']['erlang_solutions']['description'] = 'Centos $releasever - $basearch - Erlang Solutions'
 default['yum']['erlang_solutions']['gpgkey'] = 'http://packages.erlang-solutions.com/debian/erlang_solutions.asc'
 default['yum']['erlang_solutions']['gpgcheck'] = false


### PR DESCRIPTION
It breaks on EL7 and doesn't really make much sense to have in the first place. Was it supposed to be there to force EL5 hosts to use the EL6 packages or...?